### PR TITLE
Add linter support as another CI action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,11 @@
 name: Continuous integration
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
 jobs:
   build:
     name: Build
@@ -11,6 +17,7 @@ jobs:
           cd 2021-offseason
           ./gradlew downloadAll
           ./gradlew jar
+
   lint:
     name: Run checkstyle linter
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
           ./gradlew downloadAll
           ./gradlew jar
   lint:
-    name: Run linter / style check
+    name: Run checkstyle linter
     runs-on: ubuntu-latest
     container: gradle:jdk11
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,17 @@ jobs:
     container: gradle:jdk11
     steps:
       - uses: actions/checkout@v2
-      # - uses: axel-op/googlejavaformat-action@v3
-      #  with:
-      #    args: "--skip-sorting-imports --replace"
       - run: |
           cd 2021-offseason
           ./gradlew downloadAll
           ./gradlew jar
+  lint:
+    name: Run linter / style check
+    runs-on: ubuntu-latest
+    container: gradle:jdk11
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          cd 2021-offseason
+          ./gradlew downloadAll
+          ./gradlew check

--- a/2021-offseason/build.gradle
+++ b/2021-offseason/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "java"
+    id "checkstyle"
     id "edu.wpi.first.GradleRIO" version "2021.3.1"
 }
 

--- a/2021-offseason/config/checkstyle/checkstyle.xml
+++ b/2021-offseason/config/checkstyle/checkstyle.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="AvoidStarImport"/>
+    <module name="EmptyBlock"/>
+    <module name="ConstantName">
+      <!-- handle PID constants like kP/kI/kD/kFF -->
+      <property name="format"
+        value="^k[A-Z]{1,2}$|^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"/>
+    </module>
+    <module name="Indentation">
+      <property name="basicOffset" value="2" />
+      <property name="lineWrappingIndentation" value="2" />
+    </module>
+    <module name="LeftCurly"/>
+    <module name="RightCurly"/>
+  </module>
+</module>

--- a/2021-offseason/src/main/java/frc/robot/Constants.java
+++ b/2021-offseason/src/main/java/frc/robot/Constants.java
@@ -33,30 +33,30 @@ public final class Constants {
     public static final double kD = 0;
     public static final double kFF = 0.0;
     public static final double SETPOINT = (45.0/360.0) * (332.0/14.0) * 15;
-    public static final InterpolatingTreeMap<InterpolatingDouble, InterpolatingDouble> hoodAngleTreeMap = new InterpolatingTreeMap<InterpolatingDouble, InterpolatingDouble>();
+    public static final InterpolatingTreeMap<InterpolatingDouble, InterpolatingDouble> HOOD_ANGLE_MAP = new InterpolatingTreeMap<InterpolatingDouble, InterpolatingDouble>();
     public static final double[] ZONE_SETPOINTS = {37.0, 56.0, 80.0, 80.0};
     public static final int LIMIT_PORT = -1;
 
     static {
-      hoodAngleTreeMap.put(new InterpolatingDouble(50.0), new InterpolatingDouble(39.0));
-      hoodAngleTreeMap.put(new InterpolatingDouble(60.0), new InterpolatingDouble(41.0));
-      hoodAngleTreeMap.put(new InterpolatingDouble(70.0), new InterpolatingDouble(45.0));
-      hoodAngleTreeMap.put(new InterpolatingDouble(80.0), new InterpolatingDouble(49.0));
-      hoodAngleTreeMap.put(new InterpolatingDouble(90.0), new InterpolatingDouble(52.0));
-      hoodAngleTreeMap.put(new InterpolatingDouble(100.0), new InterpolatingDouble(54.0));
-      hoodAngleTreeMap.put(new InterpolatingDouble(110.0), new InterpolatingDouble(56.0));
-      hoodAngleTreeMap.put(new InterpolatingDouble(120.0), new InterpolatingDouble(57.0));
-      hoodAngleTreeMap.put(new InterpolatingDouble(130.0), new InterpolatingDouble(58.0));
-      hoodAngleTreeMap.put(new InterpolatingDouble(140.0), new InterpolatingDouble(59.0));
-      hoodAngleTreeMap.put(new InterpolatingDouble(150.0), new InterpolatingDouble(62.0));
-      hoodAngleTreeMap.put(new InterpolatingDouble(160.0), new InterpolatingDouble(64.0));
-      hoodAngleTreeMap.put(new InterpolatingDouble(170.0), new InterpolatingDouble(65.0));
-      hoodAngleTreeMap.put(new InterpolatingDouble(180.0), new InterpolatingDouble(65.0));
-      hoodAngleTreeMap.put(new InterpolatingDouble(190.0), new InterpolatingDouble(65.0));
-      hoodAngleTreeMap.put(new InterpolatingDouble(200.0), new InterpolatingDouble(66.0));
-      hoodAngleTreeMap.put(new InterpolatingDouble(210.0), new InterpolatingDouble(65.0));
-      hoodAngleTreeMap.put(new InterpolatingDouble(220.0), new InterpolatingDouble(66.0));
-      hoodAngleTreeMap.put(new InterpolatingDouble(230.0), new InterpolatingDouble(67.0));
+      HOOD_ANGLE_MAP.put(new InterpolatingDouble(50.0), new InterpolatingDouble(39.0));
+      HOOD_ANGLE_MAP.put(new InterpolatingDouble(60.0), new InterpolatingDouble(41.0));
+      HOOD_ANGLE_MAP.put(new InterpolatingDouble(70.0), new InterpolatingDouble(45.0));
+      HOOD_ANGLE_MAP.put(new InterpolatingDouble(80.0), new InterpolatingDouble(49.0));
+      HOOD_ANGLE_MAP.put(new InterpolatingDouble(90.0), new InterpolatingDouble(52.0));
+      HOOD_ANGLE_MAP.put(new InterpolatingDouble(100.0), new InterpolatingDouble(54.0));
+      HOOD_ANGLE_MAP.put(new InterpolatingDouble(110.0), new InterpolatingDouble(56.0));
+      HOOD_ANGLE_MAP.put(new InterpolatingDouble(120.0), new InterpolatingDouble(57.0));
+      HOOD_ANGLE_MAP.put(new InterpolatingDouble(130.0), new InterpolatingDouble(58.0));
+      HOOD_ANGLE_MAP.put(new InterpolatingDouble(140.0), new InterpolatingDouble(59.0));
+      HOOD_ANGLE_MAP.put(new InterpolatingDouble(150.0), new InterpolatingDouble(62.0));
+      HOOD_ANGLE_MAP.put(new InterpolatingDouble(160.0), new InterpolatingDouble(64.0));
+      HOOD_ANGLE_MAP.put(new InterpolatingDouble(170.0), new InterpolatingDouble(65.0));
+      HOOD_ANGLE_MAP.put(new InterpolatingDouble(180.0), new InterpolatingDouble(65.0));
+      HOOD_ANGLE_MAP.put(new InterpolatingDouble(190.0), new InterpolatingDouble(65.0));
+      HOOD_ANGLE_MAP.put(new InterpolatingDouble(200.0), new InterpolatingDouble(66.0));
+      HOOD_ANGLE_MAP.put(new InterpolatingDouble(210.0), new InterpolatingDouble(65.0));
+      HOOD_ANGLE_MAP.put(new InterpolatingDouble(220.0), new InterpolatingDouble(66.0));
+      HOOD_ANGLE_MAP.put(new InterpolatingDouble(230.0), new InterpolatingDouble(67.0));
     }
 
     public static final double INIT_LINE_ANGLE = 7.1;

--- a/2021-offseason/src/main/java/frc/robot/RobotContainer.java
+++ b/2021-offseason/src/main/java/frc/robot/RobotContainer.java
@@ -4,24 +4,21 @@
 
 package frc.robot;
 
-import edu.wpi.cscore.CvSink;
-import edu.wpi.cscore.CvSource;
-import edu.wpi.cscore.UsbCamera;
-import edu.wpi.first.cameraserver.CameraServer;
 import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.XboxController;
-import edu.wpi.first.wpilibj.command.WaitCommand;
-import frc.robot.commands.*;
-import frc.robot.subsystems.*;
-import frc.robot.subsystems.ExampleSubsystem;
-import frc.robot.subsystems.Flywheel;
-import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
 import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
-import edu.wpi.first.wpilibj2.command.StartEndCommand;
+import frc.robot.commands.AutoShoot;
+import frc.robot.commands.RunKicker;
+import frc.robot.subsystems.Climb;
+import frc.robot.subsystems.Drivetrain;
+import frc.robot.subsystems.Flywheel;
+import frc.robot.subsystems.Hood;
+import frc.robot.subsystems.Hopper;
+import frc.robot.subsystems.Intake;
 
 /**
  * This class is where the bulk of the robot should be declared. Since

--- a/2021-offseason/src/main/java/frc/robot/subsystems/Hopper.java
+++ b/2021-offseason/src/main/java/frc/robot/subsystems/Hopper.java
@@ -4,12 +4,10 @@
 
 package frc.robot.subsystems;
 
-import com.ctre.phoenix.*;
 import com.ctre.phoenix.motorcontrol.ControlMode;
 import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.can.TalonSRX;
 import com.ctre.phoenix.motorcontrol.can.VictorSPX;
-import com.ctre.phoenix.motorcontrol.can.TalonSRX;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;


### PR DESCRIPTION
This PR adds support for linting on PR and push time, in parallel to the build step so that it doesn't break the build. Existing lint errors are also fixed.

The linter does not create auto-pushes, and instead relies on the user to manually fix lint issues.